### PR TITLE
Update: set font weights back to normal

### DIFF
--- a/index.css
+++ b/index.css
@@ -46,35 +46,35 @@
 .text {
   strong {
     font-family: var(--font-family-bold);
-    font-weight: 700;
+    font-weight: normal;
   }
 }
 
 .heading-1 {
   font-family: var(--font-family-medium);
   font-size: calc(2.4 * var(--unit));
-  font-weight: 500;
+  font-weight: normal;
   line-height: calc(3.0 * var(--unit));
 }
 
 .heading-2 {
   font-family: var(--font-family-medium);
   font-size: calc(1.8 * var(--unit));
-  font-weight: 500;
+  font-weight: normal;
   line-height: calc(2.4 * var(--unit));
 }
 
 .heading-3 {
   font-family: var(--font-family-medium);
   font-size: calc(1.6 * var(--unit));
-  font-weight: 500;
+  font-weight: normal;
   line-height: calc(2.1 * var(--unit));
 }
 
 .heading-4 {
   font-family: var(--font-family-bold);
   font-size: calc(1.2 * var(--unit));
-  font-weight: 700;
+  font-weight: normal;
   line-height: calc(1.8 * var(--unit));
   letter-spacing: .6px;
   text-transform: uppercase;

--- a/index.html
+++ b/index.html
@@ -11,8 +11,8 @@
     <h3 class="heading heading-3">I'm a Heading H3</h3>
     <h4 class="heading heading-4">I'm a Heading H4</h4>
 
-    <p class="text text-display">I'm display text</p>
-    <p class="text text-body">I'm body text</p>
-    <p class="text text-small">I'm small text</p>
+    <p class="text text-display">I'm display text containing a <strong>strong</strong> word</p>
+    <p class="text text-body">I'm body text containing a <strong>strong</strong> word</p>
+    <p class="text text-small">I'm small text containing a <strong>strong</strong> word</p>
   </body>
 </html>


### PR DESCRIPTION
### Description
Since font weight bold has no good rendering in Safari, we had to set all font weights back to `normal` and let the font family do the magic.

#### Screenshot before this PR
![schermafdruk 2018-02-01 11 00 30](https://user-images.githubusercontent.com/5336831/35672735-b9dbfaf8-073f-11e8-9e1c-8725fd225af2.png)

#### Screenshot after this PR
![schermafdruk 2018-02-01 10 59 28](https://user-images.githubusercontent.com/5336831/35672737-bc901fe0-073f-11e8-84c6-3314a8a4836b.png)