### PR TITLE
Text body compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+## [0.2.3] - 2019-11-22
+
+### Added
+
+- `.text-body-compact`: added `text-body-compact` which has a `regular weight`, `font-size 14px` and a `line-height 18px`. ([@driesd](https://github.com/driesd) in [#12](https://github.com/teamleadercrm/ui-typography/pull/12))
+
 ## [0.2.2] - 2019-11-21
 
 ### Added

--- a/index.css
+++ b/index.css
@@ -115,6 +115,12 @@
   line-height: calc(2.1 * var(--unit));
 }
 
+.text-body-compact {
+  font-family: var(--font-family-regular);
+  font-size: calc(1.4 * var(--unit));
+  line-height: calc(1.8 * var(--unit));
+}
+
 .text-small {
   font-family: var(--font-family-regular);
   font-size: calc(1.2 * var(--unit));

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 
     <p class="text text-display">I'm display text containing a <strong>strong</strong> word</p>
     <p class="text text-body">I'm body text containing a <strong>strong</strong> word</p>
+    <p class="text text-body-compact">I'm compact body text containing a <strong>strong</strong> word</p>
     <p class="text text-small">I'm small text containing a <strong>strong</strong> word</p>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-typography",
   "private": false,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Teamleader UI typography",
   "main": "index.css",
   "repository": {


### PR DESCRIPTION
### Added

- `.text-body-compact`: added `text-body-compact` which has a `regular weight`, `font-size 14px` and a `line-height 18px`.