### PR TITLE
UI text styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 ### Fixed
 
+## [0.2.4] - 2020-03-24
+
+### Added
+
+- `.ui-text-display`: added `ui-text-display` which has a `medium weight`, `font-size 16px` and a `line-height 24px`. ([@driesd](https://github.com/driesd) in [#13](https://github.com/teamleadercrm/ui-typography/pull/13))
+- `.ui-text-body`: added `ui-text-body` which has a `medium weight`, `font-size 14px` and a `line-height 18px`. ([@driesd](https://github.com/driesd) in [#13](https://github.com/teamleadercrm/ui-typography/pull/13))
+- `.ui-text-small`: added `ui-text-small` which has a `medium weight`, `font-size 12px` and a `line-height 18px`. ([@driesd](https://github.com/driesd) in [#13](https://github.com/teamleadercrm/ui-typography/pull/13))
+
 ## [0.2.3] - 2019-11-22
 
 ### Added

--- a/index.css
+++ b/index.css
@@ -44,7 +44,8 @@
 }
 
 .heading,
-.text {
+.text,
+.ui-text {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
@@ -52,8 +53,16 @@
   font-weight: normal;
 }
 
+.ui-text {
+  font-family: var(--font-family-medium);
+}
+
 .text strong {
   font-family: var(--font-family-semi-bold);
+}
+
+.ui-text strong {
+  font-family: var(--font-family-bold);
 }
 
 .heading-1 {
@@ -116,6 +125,21 @@
 
 .text-small {
   font-family: var(--font-family-regular);
+  font-size: calc(1.2 * var(--unit));
+  line-height: calc(1.8 * var(--unit));
+}
+
+.ui-text-display {
+  font-size: calc(1.6 * var(--unit));
+  line-height: calc(2.4 * var(--unit));
+}
+
+.ui-text-body {
+  font-size: calc(1.4 * var(--unit));
+  line-height: calc(1.8 * var(--unit));
+}
+
+.ui-text-small {
   font-size: calc(1.2 * var(--unit));
   line-height: calc(1.8 * var(--unit));
 }

--- a/index.css
+++ b/index.css
@@ -49,40 +49,34 @@
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
   text-size-adjust: 100%;
+  font-weight: normal;
 }
 
-.text {
-  strong {
-    font-family: var(--font-family-semi-bold);
-    font-weight: normal;
-  }
+.text strong {
+  font-family: var(--font-family-semi-bold);
 }
 
 .heading-1 {
   font-family: var(--font-family-semi-bold);
   font-size: calc(2.4 * var(--unit));
-  font-weight: normal;
   line-height: calc(3.0 * var(--unit));
 }
 
 .heading-2 {
   font-family: var(--font-family-medium);
   font-size: calc(1.8 * var(--unit));
-  font-weight: normal;
   line-height: calc(2.4 * var(--unit));
 }
 
 .heading-3 {
   font-family: var(--font-family-medium);
   font-size: calc(1.6 * var(--unit));
-  font-weight: normal;
   line-height: calc(2.1 * var(--unit));
 }
 
 .heading-4 {
   font-family: var(--font-family-bold);
   font-size: calc(1.2 * var(--unit));
-  font-weight: normal;
   line-height: calc(1.8 * var(--unit));
   letter-spacing: .6px;
   text-transform: uppercase;
@@ -91,7 +85,6 @@
 .heading-5 {
     font-family: var(--font-family-semi-bold);
     font-size: calc(1.4 * var(--unit));
-    font-weight: normal;
     line-height: calc(1.8 * var(--unit));
 }
 

--- a/index.html
+++ b/index.html
@@ -12,9 +12,17 @@
     <h4 class="heading heading-4">I'm a Heading H4</h4>
     <h5 class="heading heading-5">I'm a Heading H5</h5>
 
+    <hr />
+
     <p class="text text-display">I'm display text containing a <strong>strong</strong> word</p>
     <p class="text text-body">I'm body text containing a <strong>strong</strong> word</p>
     <p class="text text-body-compact">I'm compact body text containing a <strong>strong</strong> word</p>
     <p class="text text-small">I'm small text containing a <strong>strong</strong> word</p>
+
+    <hr />
+
+    <p class="ui-text ui-text-display">I'm UI display text containing a <strong>strong</strong> word</p>
+    <p class="ui-text ui-text-body">I'm UI body text containing a <strong>strong</strong> word</p>
+    <p class="ui-text ui-text-small">I'm UI small text containing a <strong>strong</strong> word</p>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamleader/ui-typography",
   "private": false,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Teamleader UI typography",
   "main": "index.css",
   "repository": {


### PR DESCRIPTION
Added `.ui-text-display`, `.ui-text-body`, `.ui-text-small`.

### .ui-text-display
- **weight:** medium (500)
- **size:** 16px
- **line-height:** 24px

### .ui-text-body
- **weight:** medium (500)
- **size:** 14px
- **line-height:** 18px

### .ui-text-small
- **weight:** medium (500)
- **size:** 12px
- **line-height:** 18px


**Note:** These additional text styles may only be used inside Ahoy components.

<img width="348" alt="Screenshot 2020-03-24 15 45 41" src="https://user-images.githubusercontent.com/5336831/77438857-a1a3e580-6de6-11ea-8250-e58538148a0d.png">
