### PR TITLE
Fix monospaced font wrappers on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Firefox not correctly applying inheritance to each element of a monospaced class ([@ArnaudWeyts](https://github.com/ArnaudWeyts) in [#18])
+
 ## [2.0.2] - 2021-06-03
 
 ### Changed

--- a/index.css
+++ b/index.css
@@ -117,7 +117,7 @@
 */
 .monospaced,
 .monospaced * {
-  font-feature-settings: "tnum" on;
+  font-feature-settings: "tnum";
 }
 
 .overflow-ellipsis {

--- a/index.css
+++ b/index.css
@@ -111,7 +111,12 @@
   line-height: calc(1.8 * var(--unit));
 }
 
-.monospaced {
+/** 
+  Make sure all elements inherit the font-feature-settings
+  Firefox seems to have a bug causing no inheritance at all
+*/
+.monospaced,
+.monospaced * {
   font-feature-settings: "tnum" on;
 }
 


### PR DESCRIPTION
### Fixed

- Firefox not correctly applying inheritance to each element of a monospaced class

You can see in the screenshot that firefox claims that the settings are inherited, but the computed value to the right says otherwise, the only way to fix this is to explicitly set the property on the element.

<img width="549" alt="Screenshot 2021-06-15 at 11 46 40" src="https://user-images.githubusercontent.com/10011712/122031826-5a30bd00-cdcf-11eb-9130-43d01db38f11.png">
